### PR TITLE
Bumps Deno to v1.2 and std to v0.61

### DIFF
--- a/.github/workflows/deno_ci.yml
+++ b/.github/workflows/deno_ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: denolib/setup-deno@master
         with:
-          deno-version: v1.x
+          deno-version: v1.2.0
       - run: deno fmt --check
       - run: deno test
       

--- a/deps.ts
+++ b/deps.ts
@@ -1,15 +1,15 @@
 export const test = Deno.test;
-export { parse } from "https://deno.land/std@v0.51.0/flags/mod.ts";
+export { parse } from "https://deno.land/std@v0.61.0/flags/mod.ts";
 export {
   green,
   yellow,
   red,
   blue,
   bold,
-} from "https://deno.land/std@v0.51.0/fmt/colors.ts";
+} from "https://deno.land/std@v0.61.0/fmt/colors.ts";
 export {
   assert,
   assertEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.61.0/testing/asserts.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -10,7 +10,6 @@ export {
 export {
   assert,
   assertEquals,
-  assertStrictEq,
   assertThrows,
   assertThrowsAsync,
 } from "https://deno.land/std@v0.51.0/testing/asserts.ts";


### PR DESCRIPTION
Also removes unused dependency on `assertStrictEq`, which has become `assertStrictEqual`.