### PR TITLE
feat: pass program options to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ user, the app returns the specified default value as the value of the option)
 ```typescript
 program
   .command("foo", "Foo Test")
-  .option("-d --default", "Default Value", upercase, "bar")
+  .option("-d --default", "Default Value", uppercase, "bar")
   .action(() => {
     console.log(program.default);
   });
@@ -217,6 +217,31 @@ program
   .description("clone a repo")
   .action(({ foldername }: any) => {
     console.log("The repo is cloned into: " + foldername);
+  });
+
+program.parse(Deno.args);
+```
+
+#### Extra Parameters
+
+> Any options available in the program are passed to the callback function.
+
+```typescript
+program
+  .command("clone [foldername]")
+  .description("clone a repo")
+  .option("-b --branch", "Branch to clone")
+  .action(({ foldername }: any, { branch }: any) => {
+    console.log("Repo: " + foldername);
+    console.log("Branch: " + branch);
+  });
+
+program
+  .command("multiply", "Multiply x and y options")
+  .option("-x --xnumber", "First Number", parseInteger)
+  .option("-y --ynumber", "First Number", parseInteger)
+  .action(({ xnumber, ynumber }: any) => {
+    console.log(xnumber * ynumber);
   });
 
 program.parse(Deno.args);

--- a/src/Denomander.ts
+++ b/src/Denomander.ts
@@ -3,7 +3,6 @@ import { Command } from "./Command.ts";
 import { Kernel } from "./Kernel.ts";
 import { PublicAPI } from "./interfaces.ts";
 import { CommandOption, VersionType } from "./types.ts";
-import { Option } from "./Option.ts";
 import { CustomOption } from "./CustomOption.ts";
 
 /** The main class */

--- a/src/Executor.ts
+++ b/src/Executor.ts
@@ -2,7 +2,7 @@ import { Arguments } from "./Arguments.ts";
 import { Kernel } from "./Kernel.ts";
 import { Command } from "./Command.ts";
 import { Util } from "./Util.ts";
-import { CommandArgument, OnCommand, ValidationRules } from "./types.ts";
+import { CommandArgument, ValidationRules } from "./types.ts";
 import { Helper } from "./Helper.ts";
 import { Option } from "./Option.ts";
 import { Validator } from "./Validator.ts";
@@ -175,20 +175,20 @@ export class Executor {
     return this;
   }
 
-  /** It calls the .action() method calback function and passes the nessesery parameters */
+  /** It calls the .action() method calback function and passes the necessary parameters */
   public actionCommands(): Executor {
     this.app.available_actions.forEach((command: Command) => {
       if (this.args) {
         if (Util.isCommandInArgs(command, this.args)) {
           if (command.command_arguments.length == 0) {
-            command.action();
+            command.action(this.app);
           } else {
             let params: any = {};
             command.command_arguments.forEach((commandArg: CommandArgument) => {
               params[commandArg.argument] = commandArg.value;
             });
 
-            command.action(params);
+            command.action(params, this.app);
           }
         }
       }

--- a/tests/denomander.test.ts
+++ b/tests/denomander.test.ts
@@ -46,19 +46,25 @@ test("app_on_command", function () {
 
 test("action_command", function () {
   const program = new Denomander();
-  const args = ["clone", "githubtest"];
+  const args = ["clone", "--branch=main", "githubtest"];
 
-  let result = "";
+  let result = {
+    foldername: "",
+    branch: ""
+  };
 
   program
     .command("clone [foldername]")
-    .action(({ foldername }: any) => {
-      result = foldername;
+    .option("-b --branch", "Branch to clone")
+    .action(({ foldername }: any, { branch }: any) => {
+      result.foldername = foldername;
+      result.branch = branch;
     });
 
   program.parse(args);
 
-  assertEquals(result, "githubtest");
+  assertEquals(result.foldername, "githubtest");
+  assertEquals(result.branch, "main");
 });
 
 test("option_processing", function () {


### PR DESCRIPTION
Allows passing options to action callbacks:
```typescript
program
  .command("foo", "Foo Test")
  .option("-d --default", "Default Value", uppercase, "bar")
  .action(({ default }: any) => {
    console.log(default);
  });
program
  .command("clone [dir]", "Clone a repo")
  .option("branch", "Git branch")
  .action(({ dir }: any, { branch }: any) => {
    console.log(dir);
    console.log(branch);
  });
```

Helps for keeping commands in separate files.