### PR TITLE
Add "classic" help mode and defaultCommand()

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,6 +5,7 @@ export {
   bold,
   green,
   red,
+  reset as resetColor,
   yellow,
 } from "https://deno.land/std@0.103.0/fmt/colors.ts";
 export {

--- a/examples/another_example.ts
+++ b/examples/another_example.ts
@@ -12,7 +12,7 @@ function parseInteger(value: string): number {
   return parseInt(value);
 }
 
-function upercase(text: string): string {
+function uppercase(text: string): string {
   return text.toUpperCase();
 }
 

--- a/examples/default_command.ts
+++ b/examples/default_command.ts
@@ -1,0 +1,26 @@
+import Denomander from "../mod.ts";
+
+const program = new Denomander(
+  {
+    app_name: "echo",
+    app_description: "print a string to stdout",
+    app_version: "1.0.1",
+    options: {
+      help: "classic",
+    },
+  },
+);
+
+program
+  .defaultCommand("[msg]")
+  .argDescription("msg", "Message to print")
+  .description("print a string to stdout")
+  .action(({ msg }: any) => {
+    console.log(msg);
+  });
+
+try {
+  program.parse(Deno.args);
+} catch (error) {
+  console.log(error);
+}

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -10,9 +10,12 @@ const program = new Denomander({
     OPTION_NOT_FOUND: "Option not found!",
     COMMAND_NOT_FOUND: "Command not found!",
     REQUIRED_OPTION_NOT_FOUND: "Required option is not specified!",
-    REQUIRED_VALUE_NOT_FOUND: "Required command value is not specified!",
+    REQUIRED_VALUE_NOT_FOUND: "Required value is not specified!",
     TOO_MANY_PARAMS: "You have passed too many parameters",
     OPTION_CHOICE: "Invalid option choice!",
+    REQUIRED_COMMAND_VALUE_NOT_FOUND:
+      "Required command value is not specified!",
+    ONLY_ONE_COMMAND_ALLOWED: "Only one command is allowed in default mode!",
   },
 });
 

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -49,6 +49,12 @@ export default class Command {
 
   private _subCommands: Array<Command> = [];
 
+  private _isDefault: boolean = false;
+
+  get isDefault() {
+    return this._isDefault;
+  }
+
   /** Constructor of Command object */
   constructor(params: CommandParams) {
     this.params = Object.assign(
@@ -72,6 +78,9 @@ export default class Command {
       this._parentCommand = this.params.subCommand.parent;
       this.params.subCommand.parent.addSubCommand(this);
     }
+
+    //this._isDefault = this.params.value.startsWith("__DEFAULT__ ");
+    this._isDefault = this.params.isDefault || false;
 
     this.declaration = this.params.value;
     this.generateCommand();

--- a/src/Denomander.ts
+++ b/src/Denomander.ts
@@ -11,7 +11,19 @@ export default class Denomander extends Kernel implements PublicAPI {
 
   /** Parses the args*/
   public parse(args: Array<string>) {
-    this.args = new Arguments(args);
+    // If a default command was given, add it in order to execute it.
+    const appName = this._app_name || "__DEFAULT__";
+    const hasDefault =
+      this.commands.map(({ isDefault }) => isDefault).includes(true) &&
+      args[0] !== appName;
+    let argsList = hasDefault ? [appName, ...args] : args;
+
+    // Prevent "" from messing up arg counting
+    argsList = argsList.filter((str) => str.length > 0);
+
+    // TODO: Might need to throw error if no app_name was given.
+
+    this.args = new Arguments(argsList);
     this.args.parse();
 
     this.run();
@@ -125,6 +137,28 @@ export default class Denomander extends Kernel implements PublicAPI {
         this.action(action);
       }
     }
+
+    return this;
+  }
+
+  /** Implements the option command */
+  public defaultCommand(
+    value: string,
+    description?: string,
+    action?: Function,
+  ): Denomander {
+    const new_command: Command = new Command({
+      value: `${this._app_name} ${value}`,
+      description,
+      isDefault: true,
+    });
+    this.commands.push(new_command);
+
+    if (action) {
+      this.action(action);
+    }
+
+    this.lastCommand = new_command;
 
     return this;
   }

--- a/src/Executor.ts
+++ b/src/Executor.ts
@@ -25,7 +25,12 @@ export default class Executor {
   protected helpMode: HelpMode;
 
   /** Constructor of Executor object. */
-  constructor(app: Kernel, args: Arguments, throw_errors: boolean, helpMode: HelpMode = "default") {
+  constructor(
+    app: Kernel,
+    args: Arguments,
+    throw_errors: boolean,
+    helpMode: HelpMode = "default",
+  ) {
     this.app = app;
     this.args = args;
     this.throw_errors = throw_errors;
@@ -39,6 +44,7 @@ export default class Executor {
       args: this.args,
       rules: [ValidationRules.COMMAND_HAS_NO_ERRORS],
       throw_errors: this.throw_errors,
+      isClassic: this.app.isClassic,
     }).validate();
 
     if (this.args) {
@@ -66,12 +72,13 @@ export default class Executor {
   private printCommand(command: Command) {
     switch (this.helpMode) {
       case "classic":
-        printCommandHelpClassic(command!);
+        // this.app.BASE_COMMAND
+        printCommandHelpClassic(command!, this.app.BASE_COMMAND);
         break;
       case "default":
       case "denomander":
       default:
-        printCommandHelp(command!);
+        printCommandHelp(command!, this.app.BASE_COMMAND);
         break;
     }
   }
@@ -83,6 +90,7 @@ export default class Executor {
       args: this.args,
       rules: [ValidationRules.REQUIRED_VALUES],
       throw_errors: this.throw_errors,
+      isClassic: this.app.isClassic,
     }).validate();
 
     this.args.commands.forEach((arg: string, key: number) => {
@@ -125,6 +133,7 @@ export default class Executor {
         ValidationRules.OPTION_CHOICES,
       ],
       throw_errors: this.throw_errors,
+      isClassic: this.app.isClassic,
     }).validate();
     for (const key in this.args.options) {
       const command: Command | undefined = findCommandFromArgs(
@@ -173,6 +182,7 @@ export default class Executor {
       args: this.args,
       rules: [ValidationRules.ON_COMMANDS],
       throw_errors: this.throw_errors,
+      isClassic: this.app.isClassic,
     }).validate();
 
     this.app.on_commands.forEach((onCommand) => {

--- a/src/Executor.ts
+++ b/src/Executor.ts
@@ -3,10 +3,10 @@ import Kernel from "./Kernel.ts";
 import Command from "./Command.ts";
 import Option from "./Option.ts";
 import Validator from "./Validator.ts";
-import { CommandArgument, ValidationRules } from "./types/types.ts";
+import { CommandArgument, HelpMode, ValidationRules } from "./types/types.ts";
 import { isCommandInArgs, isOptionInArgs } from "./utils/detect.ts";
 import { findCommandFromArgs, findOptionFromArgs } from "./utils/find.ts";
-import { printCommandHelp } from "./utils/print.ts";
+import { printCommandHelp, printCommandHelpClassic } from "./utils/print.ts";
 import { setOptionValue } from "./utils/set.ts";
 import { trimDashesAndSpaces } from "./utils/remove.ts";
 
@@ -21,11 +21,15 @@ export default class Executor {
   /** The instance of the main app */
   protected app: Kernel;
 
+  /** Help message format mode. */
+  protected helpMode: HelpMode;
+
   /** Constructor of Executor object. */
-  constructor(app: Kernel, args: Arguments, throw_errors: boolean) {
+  constructor(app: Kernel, args: Arguments, throw_errors: boolean, helpMode: HelpMode = "default") {
     this.app = app;
     this.args = args;
     this.throw_errors = throw_errors;
+    this.helpMode = helpMode;
   }
 
   /** It prints the help screen and creates public app properties based on the name of the option */
@@ -47,7 +51,7 @@ export default class Executor {
 
             if (isOptionInArgs(option, this.args!)) {
               if (option.word_option == "help") {
-                printCommandHelp(command!);
+                this.printCommand(command!);
                 Deno.exit(0);
               }
             }
@@ -57,6 +61,19 @@ export default class Executor {
     }
 
     return this;
+  }
+
+  private printCommand(command: Command) {
+    switch (this.helpMode) {
+      case "classic":
+        printCommandHelpClassic(command!);
+        break;
+      case "default":
+      case "denomander":
+      default:
+        printCommandHelp(command!);
+        break;
+    }
   }
 
   /** It generates the command app variables (ex. program.clone="url...") */

--- a/src/Kernel.ts
+++ b/src/Kernel.ts
@@ -67,6 +67,13 @@ abstract class Kernel {
 
   public appOptions: AppOptions = { help: "default" };
 
+  public get isClassic() {
+    if (this.appOptions.help && this.appOptions.help === "classic") {
+      return true;
+    }
+    return false;
+  }
+
   /** The base command is needed to hold the default options like --help, --version */
   public BASE_COMMAND: Command = new Command({
     value: "_",
@@ -82,9 +89,12 @@ abstract class Kernel {
     OPTION_NOT_FOUND: "Option not found!",
     COMMAND_NOT_FOUND: "Command not found!",
     REQUIRED_OPTION_NOT_FOUND: "Required option is not specified!",
-    REQUIRED_VALUE_NOT_FOUND: "Required command value is not specified!",
+    REQUIRED_VALUE_NOT_FOUND: "Required value is not specified!",
+    REQUIRED_COMMAND_VALUE_NOT_FOUND:
+      "Required command value is not specified!",
     TOO_MANY_PARAMS: "You have passed too many parameters",
     OPTION_CHOICE: "Invalid option choice!",
+    ONLY_ONE_COMMAND_ALLOWED: "Only one command is allowed in default mode!",
   };
 
   /** User have the option to throw the errors. by default it is not enabled */
@@ -105,10 +115,9 @@ abstract class Kernel {
       if (app_details.options) {
         this.appOptions = {
           ...this.appOptions,
-          ...app_details.options
+          ...app_details.options,
         };
       }
-
     }
 
     this.versionOption = this.BASE_COMMAND.addOption({

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,11 +2,21 @@ import Command from "../Command.ts";
 import Kernel from "../Kernel.ts";
 import Arguments from "../Arguments.ts";
 
+/** Help message formats. */
+export type HelpMode = "default" | "denomander" | "classic";
+
+/** Defines extra options for the constructor. */
+export type AppOptions = {
+  /** Help message format. */
+  help: HelpMode;
+};
+
 /** Defines the app detail types */
 export type AppDetails = {
   app_name: string;
   app_description: string;
   app_version: string;
+  options?: AppOptions;
   errors?: DenomanderErrors;
   throw_errors?: boolean;
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -39,9 +39,11 @@ export type TempOnCommand = {
 /* Defines the Command constructor options */
 export type CommandParams = {
   value: string;
+  default?: boolean;
   description?: string;
   action?: Function;
   subCommand?: { parent: Command };
+  isDefault?: boolean;
 };
 
 /** Defines the args */
@@ -69,9 +71,10 @@ export type ValidatorOptions = {
   args: Arguments;
   rules: Array<ValidationRules>;
   throw_errors: boolean;
+  isClassic?: boolean;
 };
 
-/** Defines the Command constactor options */
+/** Defines the Command constructor options */
 export type CommandOption = {
   flags: string;
   description: string;
@@ -127,8 +130,10 @@ export type DenomanderErrors = {
   COMMAND_NOT_FOUND: string;
   REQUIRED_OPTION_NOT_FOUND: string;
   REQUIRED_VALUE_NOT_FOUND: string;
+  REQUIRED_COMMAND_VALUE_NOT_FOUND: string;
   TOO_MANY_PARAMS: string;
   OPTION_CHOICE: string;
+  ONLY_ONE_COMMAND_ALLOWED: string;
 };
 
 /* Enum containing the Validation Rules */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,15 +2,6 @@ import Command from "../Command.ts";
 import Kernel from "../Kernel.ts";
 import Arguments from "../Arguments.ts";
 
-/** Defines the app detail types. Applied only in Kernel constuctor */
-export type KernelAppDetails = {
-  app_name?: string;
-  app_description?: string;
-  app_version?: string;
-  errors?: DenomanderErrors;
-  throw_errors?: boolean;
-};
-
 /** Defines the app detail types */
 export type AppDetails = {
   app_name: string;
@@ -19,6 +10,9 @@ export type AppDetails = {
   errors?: DenomanderErrors;
   throw_errors?: boolean;
 };
+
+/** Defines the app detail types. Applied only in Kernel constuctor */
+export type KernelAppDetails = Partial<AppDetails>;
 
 /** Defines the .on() command options */
 export type OnCommand = {

--- a/src/utils/print.ts
+++ b/src/utils/print.ts
@@ -1,20 +1,48 @@
-import { blue, bold, green, red, yellow } from "../../deps.ts";
+import { bold, green, red, resetColor, yellow } from "../../deps.ts";
 import Command from "../Command.ts";
+import Option from "../Option.ts";
 import { AppDetails, CommandArgument } from "../types/types.ts";
 
 /** Prints success message */
-export function success_log(text: string): void {
-  console.log(green(`✅ ${text}`));
+export function success_log(text: string, classicMode: boolean = false): void {
+  console.log(classicMode ? `${text}` : green(`✅ ${text}`));
 }
 
 /** Prints warning message */
-export function warning_log(text: string): void {
-  console.log(yellow(`⚠️ ${text}`));
+export function warning_log(text: string, classicMode: boolean = false): void {
+  console.log(classicMode ? `${text}` : yellow(`⚠️ ${text}`));
 }
 
 /** Prints error message */
-export function error_log(text: string): void {
-  console.log(red(`❌ ${text}`));
+export function error_log(text: string, classicMode: boolean = false): void {
+  console.log(classicMode ? `${text}` : red(`❌ ${text}`));
+}
+
+function getUniqueOptions(array: Option[]) {
+  let options: Option[] = [];
+  let distinct: any = [];
+  for (let i = 0; i < array.length; i++) {
+    if (!distinct.includes(array[i].flags)) {
+      distinct.push(array[i].flags);
+      options.push(array[i]);
+    }
+  }
+
+  return options.sort((a, b) => {
+    return a.flags.localeCompare(b.flags);
+  });
+}
+
+function calculateSpaceNeeded(args: string[]) {
+  const lengths = args.map((str) => resetColor(str).length);
+  const largest = Math.max(...lengths);
+  return largest + 2;
+}
+
+function printFormatted(key: string, value: string, len: number, pad = false) {
+  let padStr = pad ? "  " : "";
+  let keyStr = key.padEnd(len);
+  console.log(`${padStr}${keyStr}${value}`);
 }
 
 /** The help screen. */
@@ -31,17 +59,24 @@ export function printHelp(
   console.log(app_details.app_description);
   console.log();
 
+  let commandsList = commands.filter((command) => !command.isDefault);
+
+  const maxLen = calculateSpaceNeeded([
+    ...BASE_COMMAND.options.map(({ flags }) => flags),
+    ...commandsList.map(({ value }) => value),
+  ]);
+
   console.log(yellow(bold("Options:")));
   BASE_COMMAND.options.forEach((option) => {
-    console.log(option.flags + " \t " + option.description);
+    printFormatted(option.flags, option.description, maxLen);
   });
 
   console.log();
 
-  if (commands) {
+  if (commandsList.length) {
     console.log(yellow(bold("Commands:")));
-    commands.forEach((command) => {
-      console.log(command.value + " \t " + command.description);
+    commandsList.forEach((command) => {
+      printFormatted(command.value, command.description, maxLen);
     });
     console.log();
   }
@@ -53,29 +88,47 @@ export function printHelpClassic(
   commands: Array<Command>,
   BASE_COMMAND: Command,
 ) {
+  const defaultCommand = commands.find((command) => command.isDefault);
+
+  if (defaultCommand) {
+    defaultCommand.options = getUniqueOptions([
+      ...BASE_COMMAND.options,
+      ...defaultCommand.options,
+    ]);
+    printCommandHelpClassic(defaultCommand);
+    return;
+  }
+
   console.log(`Usage: ${app_details.app_name}`);
   console.log();
   console.log(app_details.app_description);
   console.log();
 
-  console.log("Options:");
-  BASE_COMMAND.options.forEach((option) => {
-    console.log("  " + option.flags + " \t " + option.description);
-  });
+  let commandsList = commands.filter((command) => !command.isDefault);
 
+  const maxLen = calculateSpaceNeeded([
+    ...BASE_COMMAND.options.map(({ flags }) => flags),
+    ...commandsList.map(({ value }) => value),
+  ]);
+
+  console.log("Options:");
+  getUniqueOptions(BASE_COMMAND.options).forEach((option: Option) => {
+    printFormatted(option.flags, option.description, maxLen, true);
+  });
   console.log();
 
-  if (commands.length) {
+  if (commandsList.length) {
     console.log("Commands:");
-    commands.forEach((command) => {
-      console.log("  " + command.value + " \t " + command.description);
+    commandsList.forEach((command) => {
+      printFormatted(command.value, command.description, maxLen, true);
     });
     console.log();
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
 /** Print the help screen for a specific command. */
-export function printCommandHelp(command: Command) {
+export function printCommandHelpOld(command: Command, BASE_COMMAND?: Command) {
   console.log();
   if (command.hasSubCommands()) {
     console.log(yellow(bold("Subcommands:")));
@@ -94,7 +147,7 @@ export function printCommandHelp(command: Command) {
     console.log(command.description);
     console.log();
   }
-  console.log(yellow(bold("Command Usage:")));
+  console.log(yellow(bold(command.isDefault ? "Usage:" : "Command Usage:")));
   if (command.hasSubCommands()) {
     console.log(command.usage + " {Subcommand}");
   } else if (command.hasOptions()) {
@@ -103,6 +156,22 @@ export function printCommandHelp(command: Command) {
     console.log(command.usage);
   }
   console.log();
+
+  const requiredOptions: Option[] = getUniqueOptions([
+    ...command.requiredOptions,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.requiredOptions : [],
+  ]);
+
+  const options: Option[] = getUniqueOptions([
+    ...command.options,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.options : [],
+  ]);
+
+  let maxLen = calculateSpaceNeeded([
+    ...command.command_arguments.map(({ value }) => value).filter((val) => val),
+    ...requiredOptions.map(({ flags }) => flags),
+    ...options.map(({ flags }) => flags),
+  ]);
 
   if (command.command_arguments.length > 0) {
     console.log(yellow(bold("Arguments:")));
@@ -115,39 +184,50 @@ export function printCommandHelp(command: Command) {
         helpText = helpText + " \t" + commandArg.description;
       }
 
-      console.log(helpText);
+      printFormatted(command.value, command.description, maxLen);
     });
     console.log();
   }
   if (command.hasRequiredOptions()) {
     console.log(yellow(bold("Required Options:")));
-    command.requiredOptions.forEach((option) => {
-      let helpText = green(option.flags) + " \t " + option.description + " \t ";
+    requiredOptions.forEach((option) => {
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
 
       if (option.hasDefaultValue()) {
-        helpText = helpText + `(default: ${option.defaultValue})`;
+        extraStr += `(default: ${option.defaultValue})`;
+      }
+      if (option.choices) {
+        extraStr += `(choices: ${option.choices.toString()})`;
       }
 
-      if (option.choices) {
-        helpText = helpText + `(choices: ${option.choices.toString()})`;
-      }
-      console.log(helpText);
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(green(option.flags), valueStr, maxLen);
     });
     console.log();
   }
+
   console.log(yellow(bold("Options:")));
-  command.options.forEach((option) => {
+  options.forEach((option) => {
     if (!option.isRequired) {
-      let helpText = green(option.flags) + " \t " + option.description + " \t ";
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
 
       if (option.hasDefaultValue()) {
-        helpText = helpText + `(default: ${option.defaultValue})`;
+        extraStr += `(default: ${option.defaultValue})`;
       }
 
       if (option.choices) {
-        helpText = helpText + `(choices: ${option.choices.toString()})`;
+        extraStr += `(choices: ${option.choices.toString()})`;
       }
-      console.log(helpText);
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(green(option.flags), valueStr, maxLen);
     }
   });
   console.log();
@@ -157,9 +237,153 @@ export function printCommandHelp(command: Command) {
   }
 }
 
-/** Print the help screen for a specific command (Classic). */
-export function printCommandHelpClassic(command: Command) {
+/** Print the help screen for a specific command. */
+export function printCommandHelp(command: Command, BASE_COMMAND?: Command) {
   let usage = command.usage;
+
+  if (command.isDefault) {
+    usage = usage.replace(/^__DEFAULT__ /, "");
+  }
+
+  if (command.hasSubCommands()) {
+    usage += " {subcommand}";
+  } else if (command.hasOptions()) {
+    usage += " {options}";
+  }
+
+  console.log();
+  console.log(yellow(bold(command.isDefault ? "Usage:" : "Command Usage:")));
+  console.log(usage);
+  console.log();
+
+  if (command.description) {
+    console.log(yellow(bold("Description:")));
+    console.log(command.description);
+    console.log();
+  }
+
+  if (command.hasSubCommands()) {
+    console.log(yellow(bold("Subcommands:")));
+    command.subCommands.map((subCommand: Command) => {
+      console.log(subCommand.word_command);
+    });
+    console.log();
+  }
+  if (command.isSubCommand()) {
+    console.log(yellow(bold("Parent Command:")));
+    console.log(command.parentCommand?.word_command);
+    console.log();
+  }
+
+  const requiredOptions: Option[] = getUniqueOptions([
+    ...command.requiredOptions,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.requiredOptions : [],
+  ]);
+
+  const options: Option[] = getUniqueOptions([
+    ...command.options,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.options : [],
+  ]);
+
+  let maxLen = calculateSpaceNeeded([
+    ...command.command_arguments.map(({ value }) => value).filter((val) => val),
+    ...requiredOptions.map(({ flags }) => flags),
+    ...options.map(({ flags }) => flags),
+  ]) + 1; // Not sure why it needs the extra 1.
+
+  if (command.command_arguments.length > 0) {
+    const hasRequired = command.command_arguments
+      .map(({ isRequired }) => isRequired)
+      .includes(true);
+    let commandsLen = calculateSpaceNeeded(
+      command.command_arguments.map(({ argument }) => argument),
+    );
+    if (hasRequired) {
+      commandsLen += 1;
+    }
+
+    maxLen = Math.max(maxLen, commandsLen);
+
+    console.log(yellow(bold("Arguments:")));
+    command.command_arguments.forEach((commandArg: CommandArgument) => {
+      let helpText = green(
+        `${commandArg.argument}${commandArg.isRequired ? "" : "?"}`,
+      );
+
+      if (commandArg.description) {
+        printFormatted(helpText, commandArg.description, maxLen);
+      } else {
+        console.log(helpText);
+      }
+    });
+    console.log();
+  }
+  if (command.hasRequiredOptions()) {
+    console.log(yellow(bold("Required Options:")));
+    requiredOptions.forEach((option) => {
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
+
+      if (option.hasDefaultValue()) {
+        extraStr += `(default: ${option.defaultValue})`;
+      }
+
+      if (option.choices) {
+        extraStr += `(choices: ${option.choices.toString()})`;
+      }
+
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(green(option.flags), valueStr, maxLen);
+    });
+    console.log();
+  }
+
+  console.log(yellow(bold("Options:")));
+  options.forEach((option: Option) => {
+    if (!option.isRequired) {
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
+
+      if (option.hasDefaultValue()) {
+        extraStr += `(default: ${option.defaultValue})`;
+      }
+
+      if (option.choices) {
+        extraStr += `(choices: ${option.choices.toString()})`;
+      }
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(green(option.flags), valueStr, maxLen);
+    }
+  });
+
+  console.log();
+  if (command.hasAlias()) {
+    console.log(yellow(bold("Aliases:")));
+    command.aliases.forEach((alias) => {
+      console.log(alias);
+    });
+  }
+}
+
+/** Print the help screen for a specific command (Classic). */
+export function printCommandHelpClassic(
+  command: Command,
+  BASE_COMMAND?: Command,
+) {
+  let usage = command.usage;
+
+  // ...BASE_COMMAND.options,
+
+  if (command.isDefault) {
+    usage = usage.replace(/^__DEFAULT__ /, "");
+  }
+
   if (command.hasSubCommands()) {
     usage += " {subcommand}";
   } else if (command.hasOptions()) {
@@ -186,57 +410,97 @@ export function printCommandHelpClassic(command: Command) {
     console.log();
   }
 
+  const requiredOptions: Option[] = getUniqueOptions([
+    ...command.requiredOptions,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.requiredOptions : [],
+  ]);
+
+  const options: Option[] = getUniqueOptions([
+    ...command.options,
+    ...(BASE_COMMAND && command.isDefault) ? BASE_COMMAND.options : [],
+  ]);
+
+  let maxLen = calculateSpaceNeeded([
+    ...requiredOptions.map(({ flags }) => flags),
+    ...options.map(({ flags }) => flags),
+  ]);
+
   if (command.command_arguments.length > 0) {
+    const hasRequired = command.command_arguments
+      .map(({ isRequired }) => isRequired)
+      .includes(true);
+    let commandsLen = calculateSpaceNeeded(
+      command.command_arguments.map(({ argument }) => argument),
+    );
+    if (hasRequired) {
+      commandsLen += 1;
+    }
+
+    maxLen = Math.max(maxLen, commandsLen);
+
     console.log("Arguments:");
     command.command_arguments.forEach((commandArg: CommandArgument) => {
-      let helpText =
-        `  ${commandArg.argument}${commandArg.isRequired ? "" : "?"}`
-        ;
+      let helpText = `${commandArg.argument}${
+        commandArg.isRequired ? "" : "?"
+      }`;
 
       if (commandArg.description) {
-        helpText = helpText + " \t " + commandArg.description;
+        printFormatted(helpText, commandArg.description, maxLen, true);
+      } else {
+        console.log(helpText);
       }
-
-      console.log(helpText);
     });
     console.log();
   }
   if (command.hasRequiredOptions()) {
     console.log("Required Options:");
-    command.requiredOptions.forEach((option) => {
-      let helpText = "  " + option.flags + " \t " + option.description + " \t ";
+    requiredOptions.forEach((option) => {
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
 
       if (option.hasDefaultValue()) {
-        helpText = helpText + `(default: ${option.defaultValue})`;
+        extraStr += `(default: ${option.defaultValue})`;
       }
 
       if (option.choices) {
-        helpText = helpText + `(choices: ${option.choices.toString()})`;
+        extraStr += `(choices: ${option.choices.toString()})`;
       }
-      console.log(helpText);
+
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(option.flags, valueStr, maxLen, true);
     });
     console.log();
   }
+
   console.log("Options:");
-  command.options.forEach((option) => {
+  options.forEach((option: Option) => {
     if (!option.isRequired) {
-      let helpText = "  " + option.flags + " \t " + option.description + " \t ";
+      let extraStr = "";
+
+      if (option.hasDefaultValue() || option.choices) {
+        extraStr += "\t";
+      }
 
       if (option.hasDefaultValue()) {
-        helpText = helpText + `(default: ${option.defaultValue})`;
+        extraStr += `(default: ${option.defaultValue})`;
       }
 
       if (option.choices) {
-        helpText = helpText + `(choices: ${option.choices.toString()})`;
+        extraStr += `(choices: ${option.choices.toString()})`;
       }
-      console.log(helpText);
+      const valueStr = `${option.description}${extraStr}`;
+      printFormatted(option.flags, valueStr, maxLen, true);
     }
   });
+
   console.log();
   if (command.hasAlias()) {
     console.log("Aliases:");
     command.aliases.forEach((alias) => {
-      console.log("  " + alias)
+      console.log("  " + alias);
     });
   }
 }

--- a/src/utils/print.ts
+++ b/src/utils/print.ts
@@ -17,8 +17,8 @@ export function error_log(text: string): void {
   console.log(red(`❌ ${text}`));
 }
 
-/** The help screen */
-export function print_help(
+/** The help screen. */
+export function printHelp(
   app_details: AppDetails,
   commands: Array<Command>,
   BASE_COMMAND: Command,
@@ -45,7 +45,34 @@ export function print_help(
   console.log();
 }
 
-/** Print the help screen for a specific command */
+/** The help screen. */
+export function printHelpClassic(
+  app_details: AppDetails,
+  commands: Array<Command>,
+  BASE_COMMAND: Command,
+) {
+  console.log(`Usage: ${app_details.app_name}`);
+  console.log();
+  console.log(app_details.app_description);
+  console.log();
+
+  console.log("Options:");
+  BASE_COMMAND.options.forEach((option) => {
+    console.log("  " + option.flags + " \t " + option.description);
+  });
+
+  console.log();
+
+  if (commands.length) {
+    console.log("Commands:");
+    commands.forEach((command) => {
+      console.log("  " + command.value + " \t " + command.description);
+    });
+    console.log();
+  }
+}
+
+/** Print the help screen for a specific command. */
 export function printCommandHelp(command: Command) {
   console.log();
   if (command.hasSubCommands()) {
@@ -125,5 +152,89 @@ export function printCommandHelp(command: Command) {
   if (command.hasAlias()) {
     console.log(yellow(bold("Aliases:")));
     command.aliases.forEach((alias) => console.log(alias));
+  }
+}
+
+/** Print the help screen for a specific command (Classic). */
+export function printCommandHelpClassic(command: Command) {
+  let usage = command.usage;
+  if (command.hasSubCommands()) {
+    usage += " {subcommand}";
+  } else if (command.hasOptions()) {
+    usage += " {options}";
+  }
+  console.log(`Usage: ${usage}`);
+  console.log();
+
+  if (command.description) {
+    console.log(command.description);
+    console.log();
+  }
+
+  if (command.hasSubCommands()) {
+    console.log("Subcommands:");
+    command.subCommands.map((subCommand: Command) => {
+      console.log("  " + subCommand.word_command);
+    });
+    console.log();
+  }
+  if (command.isSubCommand()) {
+    console.log("Parent Command:");
+    console.log("  " + command.parentCommand?.word_command);
+    console.log();
+  }
+
+  if (command.command_arguments.length > 0) {
+    console.log("Arguments:");
+    command.command_arguments.forEach((commandArg: CommandArgument) => {
+      let helpText =
+        `  ${commandArg.argument}${commandArg.isRequired ? "" : "?"}`
+        ;
+
+      if (commandArg.description) {
+        helpText = helpText + " \t " + commandArg.description;
+      }
+
+      console.log(helpText);
+    });
+    console.log();
+  }
+  if (command.hasRequiredOptions()) {
+    console.log("Required Options:");
+    command.requiredOptions.forEach((option) => {
+      let helpText = "  " + option.flags + " \t " + option.description + " \t ";
+
+      if (option.hasDefaultValue()) {
+        helpText = helpText + `(default: ${option.defaultValue})`;
+      }
+
+      if (option.choices) {
+        helpText = helpText + `(choices: ${option.choices.toString()})`;
+      }
+      console.log(helpText);
+    });
+    console.log();
+  }
+  console.log("Options:");
+  command.options.forEach((option) => {
+    if (!option.isRequired) {
+      let helpText = "  " + option.flags + " \t " + option.description + " \t ";
+
+      if (option.hasDefaultValue()) {
+        helpText = helpText + `(default: ${option.defaultValue})`;
+      }
+
+      if (option.choices) {
+        helpText = helpText + `(choices: ${option.choices.toString()})`;
+      }
+      console.log(helpText);
+    }
+  });
+  console.log();
+  if (command.hasAlias()) {
+    console.log("Aliases:");
+    command.aliases.forEach((alias) => {
+      console.log("  " + alias)
+    });
   }
 }

--- a/src/utils/print.ts
+++ b/src/utils/print.ts
@@ -38,11 +38,13 @@ export function printHelp(
 
   console.log();
 
-  console.log(yellow(bold("Commands:")));
-  commands.forEach((command) => {
-    console.log(command.value + " \t " + command.description);
-  });
-  console.log();
+  if (commands) {
+    console.log(yellow(bold("Commands:")));
+    commands.forEach((command) => {
+      console.log(command.value + " \t " + command.description);
+    });
+    console.log();
+  }
 }
 
 /** The help screen. */

--- a/tests/command.test.ts
+++ b/tests/command.test.ts
@@ -58,6 +58,17 @@ test("command_alias", function () {
   assertEquals(command.aliases, ["alias1", "alias2"]);
 });
 
+test("default_command", function () {
+  const command = new Command({
+    value: "[msg]",
+    description: "Print a message",
+    isDefault: true,
+  });
+
+  assertEquals(command.isDefault, true);
+  assertEquals(command.word_command, "[msg]"); // Command name is still the first parameter
+});
+
 test("sub_commands", function () {
   const parent_command = new Command({ value: "parent" });
   const sub_command = new Command({

--- a/tests/validations.test.ts
+++ b/tests/validations.test.ts
@@ -59,6 +59,23 @@ test("validation_command_with_required_argument_throws_error", function () {
       program.command("clone [repo]", "Clone the repo").parse(args);
     },
     Error,
+    program.errors.REQUIRED_COMMAND_VALUE_NOT_FOUND,
+  );
+});
+
+test("validation_default_command_with_required_argument_throws_error", function () {
+  const args: string[] = [];
+
+  const program = new Denomander({
+    app_name: "myapp", // default command requires app_name.
+    throw_errors: true,
+  });
+
+  assertThrows(
+    () => {
+      program.defaultCommand("[from]").parse(args);
+    },
+    Error,
     program.errors.REQUIRED_VALUE_NOT_FOUND,
   );
 });


### PR DESCRIPTION
This pull request adds two features designed to help denomander become more useful for commandless CLIs. It adds a `defaultCommand()` function to allow executing an action by default instead of needing a command name passed, and it adds an option for a "classic" help mode that more closely resembles UNIX-like help messages.

## Classic help mode
By default, the help output looks like this:
```

My MY App
v1.0.1

Description:
My MY Description

Options:
-h --help             Help Screen
-V --version          Version

Commands:
add [title]           Multiply x and y options

```

It includes colors and emoji icons. Classic mode removes all colors and emojis and prints closer to most UNIX-style help messages:
```
Usage: My MY App

My MY Description

Options:
  -h --help             Help Screen
  -V --version          Version

Commands:
  add [title]           Multiply x and y options

```

To enable classic mode, see below.

## Default command

This adds a feature to allow an `.action()` to be executed without needing to pass a command name like add or commit. It still supports adding options and parameters, including checking for the number of required args.

## Example

```ts
import Denomander from "../mod.ts";

const program = new Denomander(
  {
    app_name: "echo",
    app_description: "print a string to stdout",
    app_version: "1.0.1",
    options: {
      help: "classic",
    },
  },
);

program
  .defaultCommand("[msg]")
  .argDescription("msg", "Message to print")
  .description("print a string to stdout")
  .action(({ msg }: any) => {
    console.log(msg);
  });

try {
  program.parse(Deno.args);
} catch (error) {
  console.log(error);
}
```

## Notes

The three recognized help modes are `default`, `denomander`, and `classic`. If none is given, then the default (`denomander`) is used, so users will not see a difference unless they explicitly enable classic mode.

It also adds a patch to align descriptions correctly:
```
  -h --help     Help Screen
  -V --version  Version
```
instead of
```
  -h --help     Help Screen
  -V --version      Version
```

At this time, classic help mode is enabled by using `options.help`. `help` is the only recognized property of `options` at this time.

**This did involve a fair number of changes, so I highly recommend reviewing the code before merging!**